### PR TITLE
Some suggestions

### DIFF
--- a/SolastaModHelpers/Common.cs
+++ b/SolastaModHelpers/Common.cs
@@ -1,16 +1,13 @@
 ﻿using SolastaModApi;
-using System;
+using SolastaModApi.Infrastructure;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static RuleDefinitions;
 
 namespace SolastaModHelpers
 {
     public class Common
     {
-        public static Dictionary<RuleDefinitions.RitualCasting, FeatureDefinitionMagicAffinity> ritual_spellcastings_map = new Dictionary<RitualCasting, FeatureDefinitionMagicAffinity>();
+        public static Dictionary<RitualCasting, FeatureDefinitionMagicAffinity> ritual_spellcastings_map = new Dictionary<RitualCasting, FeatureDefinitionMagicAffinity>();
         public static string common_condition_prefix = "Rules/&CommonConditioUnderEffectOfPrefix";
         public static string common_no_title = "Feature/&NoContentTitle";
 
@@ -22,8 +19,8 @@ namespace SolastaModHelpers
 
         static void fillRitualSpellcastingMap()
         {
-            ritual_spellcastings_map[RuleDefinitions.RitualCasting.Prepared] = DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinityClericRitualCasting;
-            ritual_spellcastings_map[RuleDefinitions.RitualCasting.Spellbook] = DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinityWizardRitualCasting;
+            ritual_spellcastings_map[RitualCasting.Prepared] = DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinityClericRitualCasting;
+            ritual_spellcastings_map[RitualCasting.Spellbook] = DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinityWizardRitualCasting;
 
             var spontaneous_ritual_spellcsting = Helpers.CopyFeatureBuilder<FeatureDefinitionMagicAffinity>.createFeatureCopy("MagicAffinitySpontaneousRitualCasting",
                                                                                                                               "efd3d247-d74f-47ac-b575-159fcad3608f",
@@ -32,8 +29,9 @@ namespace SolastaModHelpers
                                                                                                                               null,
                                                                                                                               DatabaseHelper.FeatureDefinitionMagicAffinitys.MagicAffinityClericRitualCasting
                                                                                                                               );
-            Helpers.Accessors.SetField(spontaneous_ritual_spellcsting, "ritualCasting", (RuleDefinitions.RitualCasting)ExtendedEnums.ExtraRitualCasting.Spontaneous);
-            ritual_spellcastings_map[(RuleDefinitions.RitualCasting)ExtendedEnums.ExtraRitualCasting.Spontaneous] = spontaneous_ritual_spellcsting;
+            
+            spontaneous_ritual_spellcsting.SetField("ritualCasting", (RitualCasting)ExtendedEnums.ExtraRitualCasting.Spontaneous);
+            ritual_spellcastings_map[(RitualCasting)ExtendedEnums.ExtraRitualCasting.Spontaneous] = spontaneous_ritual_spellcsting;
         }
     }
 }

--- a/SolastaModHelpers/ExtendedEnums.cs
+++ b/SolastaModHelpers/ExtendedEnums.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.ExtendedEnums
 {

--- a/SolastaModHelpers/GuidStorage.cs
+++ b/SolastaModHelpers/GuidStorage.cs
@@ -1,9 +1,6 @@
 ﻿using SolastaModApi;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers
 {
@@ -38,7 +35,7 @@ namespace SolastaModHelpers
             {
                 foreach (var pair in guids_in_use)
                 {
-                  sw.WriteLine(pair.Key + '\t' + pair.Value);
+                    sw.WriteLine(pair.Key + '\t' + pair.Value);
                 }
             }
         }
@@ -102,19 +99,19 @@ namespace SolastaModHelpers
 
 
     public class BaseDefinitionBuilderWithGuidStorage<TDefinition> : BaseDefinitionBuilder<TDefinition> where TDefinition : BaseDefinition
-    { 
+    {
         protected BaseDefinitionBuilderWithGuidStorage(TDefinition original)
-            :base(original)
+            : base(original)
         {
 
         }
         protected BaseDefinitionBuilderWithGuidStorage(string name, string guid)
-            :base(name, guid == "" ? GuidStorage.getGuid(name) : guid)
+            : base(name, guid == "" ? GuidStorage.getGuid(name) : guid)
         {
             GuidStorage.addEntry(name, Definition.GUID);
         }
         protected BaseDefinitionBuilderWithGuidStorage(TDefinition original, string name, string guid)
-            :base(original, name, guid == "" ? GuidStorage.getGuid(name) : guid)
+            : base(original, name, guid == "" ? GuidStorage.getGuid(name) : guid)
         {
             GuidStorage.addEntry(name, Definition.GUID);
         }

--- a/SolastaModHelpers/Helpers.cs
+++ b/SolastaModHelpers/Helpers.cs
@@ -8,18 +8,13 @@ using UnityEngine.AddressableAssets;
 using static FeatureDefinitionAbilityCheckAffinity;
 using static FeatureDefinitionSavingThrowAffinity;
 using static SpellListDefinition;
+using static AttributeDefinitions;
+using static SkillDefinitions;
 
 namespace SolastaModHelpers.Helpers
 {
     public static class Stats
     {
-        public static string Strength = "Strength";
-        public static string Dexterity = "Dexterity";
-        public static string Constitution = "Constitution";
-        public static string Wisdom = "Wisdom";
-        public static string Intelligence = "Intelligence";
-        public static string Charisma = "Charisma";
-
         public static string[] getAllStats()
         {
             return typeof(Stats).GetFields(BindingFlags.Public | BindingFlags.Static).Select(f => f.GetValue(null)).Cast<string>().ToArray();
@@ -37,7 +32,7 @@ namespace SolastaModHelpers.Helpers
             {
                 if (!all_stats.Contains(s))
                 {
-                    throw new System.Exception(s + "is not an Ability");
+                    throw new Exception(s + "is not an Ability");
                 }
             }
         }
@@ -68,7 +63,7 @@ namespace SolastaModHelpers.Helpers
             {
                 if (!all_profs.Contains(p))
                 {
-                    throw new System.Exception(p + "is not an Armor Proficiency");
+                    throw new Exception(p + "is not an Armor Proficiency");
                 }
             }
         }
@@ -98,7 +93,7 @@ namespace SolastaModHelpers.Helpers
             {
                 if (!all_conditions.Contains(c))
                 {
-                    throw new System.Exception(c + "is not a Condition");
+                    throw new Exception(c + "is not a Condition");
                 }
             }
         }
@@ -106,45 +101,26 @@ namespace SolastaModHelpers.Helpers
 
     public static class Skills
     {
-        public static string Acrobatics = "Acrobatics";
-        public static string Arcana = "Arcana";
-        public static string AnimalHandling = "AnimalHandling";
-        public static string Athletics = "Athletics";
-        public static string Deception = "Deception";
-        public static string History = "History";
-        public static string Insight = "Insight";
-        public static string Intimidation = "Intimidation";
-        public static string Investigation = "Investigation";
-        public static string Medicine = "Medecine";
-        public static string Nature = "Nature";
-        public static string Perception = "Perception";
-        public static string Perfromance = "Performance";
-        public static string Persuasion = "Persuasion";
-        public static string Religion = "Religion";
-        public static string SleightOfHand = "SleightOfHand";
-        public static string Stealth = "Stealth";
-        public static string Survival = "Survival";
-
         public static Dictionary<string, string> skill_stat_map = new Dictionary<string, string>
         {
-            {Acrobatics, Stats.Dexterity },
-            {Arcana, Stats.Intelligence },
-            {AnimalHandling, Stats.Wisdom },
-            {Athletics, Stats.Strength },
-            {Deception, Stats.Charisma },
-            {History, Stats.Intelligence },
-            {Insight, Stats.Wisdom },
-            {Intimidation, Stats.Charisma },
-            {Investigation, Stats.Intelligence },
-            {Medicine, Stats.Wisdom },
-            {Nature, Stats.Intelligence },
-            {Perception, Stats.Wisdom },
-            {Perfromance, Stats.Charisma },
-            {Persuasion, Stats.Charisma },
-            {Religion, Stats.Wisdom },
-            {SleightOfHand, Stats.Dexterity },
-            {Stealth, Stats.Dexterity },
-            {Survival, Stats.Wisdom }
+            {Acrobatics, Dexterity },
+            {Arcana, Intelligence },
+            {AnimalHandling, Wisdom },
+            {Athletics, Strength },
+            {Deception, Charisma },
+            {History, Intelligence },
+            {Insight, Wisdom },
+            {Intimidation, Charisma },
+            {Investigation, Intelligence },
+            {Medecine, Wisdom },
+            {Nature, Intelligence },
+            {Perception, Wisdom },
+            {Performance, Charisma },
+            {Persuasion, Charisma },
+            {Religion, Wisdom },
+            {SleightOfHand, Dexterity },
+            {Stealth, Dexterity },
+            {Survival, Wisdom }
         };
 
         public static string[] getAllSkills()
@@ -164,7 +140,7 @@ namespace SolastaModHelpers.Helpers
             {
                 if (!all_stats.Contains(s))
                 {
-                    throw new System.Exception(s + "is not a Skill");
+                    throw new Exception(s + "is not a Skill");
                 }
             }
         }
@@ -172,14 +148,6 @@ namespace SolastaModHelpers.Helpers
 
     public static class Tools
     {
-        public static string ScrollKit = "ScrollKitType";
-        public static string EnchantingTool = "EnchantingToolType";
-        public static string SmithTool = "ArtisanToolSmithToolsType";
-        public static string ThievesTool = "ThievesToolsType";
-        public static string HerbalismKit = "HerbalismKitType";
-        public static string PoisonerKit = "PoisonersKitType";
-        public static string Lyre = "MusicalInstrumentLyreType";
-
         public static string[] getAllTools()
         {
             return typeof(Tools).GetFields(BindingFlags.Public | BindingFlags.Static).Select(f => f.GetValue(null)).Cast<string>().ToArray();
@@ -197,7 +165,7 @@ namespace SolastaModHelpers.Helpers
             {
                 if (!all_stats.Contains(s))
                 {
-                    throw new System.Exception(s + "is not a Tool");
+                    throw new Exception(s + "is not a Tool");
                 }
             }
         }
@@ -482,7 +450,7 @@ namespace SolastaModHelpers.Helpers
                                           string condition_type,
                                           RuleDefinitions.ConditionAffinityType affinity,
                                           RuleDefinitions.AdvantageType saving_throw_advantage_type,
-                                          RuleDefinitions.AdvantageType reroll_advantage_type) : 
+                                          RuleDefinitions.AdvantageType reroll_advantage_type) :
             base(DatabaseHelper.FeatureDefinitionConditionAffinitys.ConditionAffinityElfFeyAncestryCharm, name, guid)
         {
             if (title_string != "")
@@ -790,7 +758,7 @@ namespace SolastaModHelpers.Helpers
             return new CopyFeatureBuilder<TDefinition>(name, guid, title_string, description_string, sprite, base_feature).AddToDB();
         }
 
-        public static TDefinition createFeatureCopy(string name, string guid, string title_string, string description_string, AssetReferenceSprite sprite, 
+        public static TDefinition createFeatureCopy(string name, string guid, string title_string, string description_string, AssetReferenceSprite sprite,
                                                         TDefinition base_feature, Action<TDefinition> action)
         {
             var res = new CopyFeatureBuilder<TDefinition>(name, guid, title_string, description_string, sprite, base_feature).AddToDB();
@@ -827,7 +795,7 @@ namespace SolastaModHelpers.Helpers
 
         public static TDefinition createFeature(string name, string guid, string title_string, string description_string, AssetReferenceSprite sprite, Action<TDefinition> action)
         {
-            var res =  new FeatureBuilder<TDefinition>(name, guid, title_string, description_string, sprite).AddToDB();
+            var res = new FeatureBuilder<TDefinition>(name, guid, title_string, description_string, sprite).AddToDB();
             action(res);
             return res;
         }
@@ -914,7 +882,7 @@ namespace SolastaModHelpers.Helpers
     }
 
 
-    public class GenericPowerBuilder<T> : BaseDefinitionBuilderWithGuidStorage<T> where T: FeatureDefinitionPower
+    public class GenericPowerBuilder<T> : BaseDefinitionBuilderWithGuidStorage<T> where T : FeatureDefinitionPower
     {
         protected GenericPowerBuilder(string name, string guid, string title_string, string description_string, AssetReferenceSprite sprite,
                                        EffectDescription effect_description,
@@ -1013,7 +981,7 @@ namespace SolastaModHelpers.Helpers
             }
         }
 
-        static public List<T> extractFeaturesHierarchically<T>(IEnumerable<FeatureDefinition> features) where T: class
+        static public List<T> extractFeaturesHierarchically<T>(IEnumerable<FeatureDefinition> features) where T : class
         {
             var list = new List<T>();
             foreach (var f in features)

--- a/SolastaModHelpers/Main.cs
+++ b/SolastaModHelpers/Main.cs
@@ -1,18 +1,14 @@
+using HarmonyLib;
+using I2.Loc;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using UnityModManagerNet;
-using HarmonyLib;
-using I2.Loc;
-using SolastaModApi;
-using SolastaModApi.Extensions;
-using SolastaModHelpers;
-using System.Collections.Generic;
 
 namespace SolastaModHelpers
 {
-    public class Main
+    public static class Main
     {
         [Conditional("DEBUG")]
         internal static void Log(string msg) => Logger.Log(msg);
@@ -33,7 +29,7 @@ namespace SolastaModHelpers
                 var languageIndex = languageSourceData.GetLanguageIndexFromCode(code);
 
                 if (languageIndex < 0)
-                    Main.Error($"language {code} not currently loaded.");
+                    Error($"language {code} not currently loaded.");
                 else
                     using (var sr = new StreamReader(filename))
                     {

--- a/SolastaModHelpers/NewFeatureDefinitions/CharacterActions.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/CharacterActions.cs
@@ -1,11 +1,7 @@
-﻿using SolastaModHelpers.NewFeatureDefinitions;
-using SolastaModApi;
-using System;
+﻿using SolastaModApi;
+using SolastaModHelpers.NewFeatureDefinitions;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.NewFeatureDefinitions
 {
@@ -43,7 +39,6 @@ public class CharacterActionModifyAttackRollViaPower : CharacterActionUsePower
         CharacterActionModifyAttackRollViaPower actionModifyAttackRoll = this;
         GameLocationCharacter attacker = actionModifyAttackRoll.ActionParams.TargetCharacters[0];
         GameLocationCharacter defender = actionModifyAttackRoll.ActionParams.TargetCharacters[1];
-        var action_modifier = actionModifyAttackRoll.ActionParams.ActionModifiers[0];
         var power = actionParams.UsablePower.PowerDefinition;
         foreach (var e in power.EffectDescription.effectForms)
         {

--- a/SolastaModHelpers/NewFeatureDefinitions/ExtraHealingDie.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/ExtraHealingDie.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SolastaModHelpers.NewFeatureDefinitions
+﻿namespace SolastaModHelpers.NewFeatureDefinitions
 {
     public class FeatureDefinitionExtraHealingDieOnShortRest : FeatureDefinition
     {

--- a/SolastaModHelpers/NewFeatureDefinitions/ExtraSpellSelection.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/ExtraSpellSelection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace SolastaModHelpers.NewFeatureDefinitions
 {

--- a/SolastaModHelpers/NewFeatureDefinitions/GrantSpells.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/GrantSpells.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace SolastaModHelpers.NewFeatureDefinitions
 {
-    public class GrantSpells: FeatureDefinition
+    public class GrantSpells : FeatureDefinition
     {
         public List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup> spellGroups = new List<FeatureDefinitionAutoPreparedSpells.AutoPreparedSpellsGroup>();
         public CharacterClassDefinition spellcastingClass;

--- a/SolastaModHelpers/NewFeatureDefinitions/LinkedPower.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/LinkedPower.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace SolastaModHelpers.NewFeatureDefinitions
 {

--- a/SolastaModHelpers/NewFeatureDefinitions/ModifyDiceRollValue.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/ModifyDiceRollValue.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.NewFeatureDefinitions
 {
@@ -11,7 +8,7 @@ namespace SolastaModHelpers.NewFeatureDefinitions
         int processDiceRoll(RuleDefinitions.RollContext context, int rolled_value, RulesetActor roller);
     }
 
-    public class ModifyDiceRollValue: FeatureDefinition, IModifyDiceRollValue
+    public class ModifyDiceRollValue : FeatureDefinition, IModifyDiceRollValue
     {
         public int numDice;
         public RuleDefinitions.DieType diceType;

--- a/SolastaModHelpers/NewFeatureDefinitions/ReactionPowers.cs
+++ b/SolastaModHelpers/NewFeatureDefinitions/ReactionPowers.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SolastaModHelpers.NewFeatureDefinitions
+﻿namespace SolastaModHelpers.NewFeatureDefinitions
 {
     public interface IReactionPowerOnAttackAttempt
     {
@@ -18,7 +12,7 @@ namespace SolastaModHelpers.NewFeatureDefinitions
     }
 
 
-    public class FeatureDefinitionReactionPowerOnDamage: NewFeatureDefinitions.LinkedPower, IReactionPowerOnDamage
+    public class FeatureDefinitionReactionPowerOnDamage : LinkedPower, IReactionPowerOnDamage
     {
         public bool worksOnMelee;
         public bool worksOnRanged;
@@ -33,7 +27,7 @@ namespace SolastaModHelpers.NewFeatureDefinitions
             }
 
             int max_distance = this.EffectDescription.RangeParameter;
-            
+
             if ((caster.LocationPosition - attacker.LocationPosition).magnitude > max_distance)
             {
                 return false;
@@ -63,7 +57,7 @@ namespace SolastaModHelpers.NewFeatureDefinitions
             {
                 return false;
             }
-            
+
             if (!works_on_caster && attacker == caster)
             {
                 return false;
@@ -74,7 +68,7 @@ namespace SolastaModHelpers.NewFeatureDefinitions
     }
 
 
-    public class FeatureDefinitionReactionPowerOnAttackAttempt : NewFeatureDefinitions.LinkedPower, IReactionPowerOnAttackAttempt
+    public class FeatureDefinitionReactionPowerOnAttackAttempt : LinkedPower, IReactionPowerOnAttackAttempt
     {
         public bool worksOnMelee;
         public bool worksOnRanged;

--- a/SolastaModHelpers/Patches/CharacterActionPatcher.cs
+++ b/SolastaModHelpers/Patches/CharacterActionPatcher.cs
@@ -1,9 +1,5 @@
 ﻿using HarmonyLib;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {
@@ -14,7 +10,7 @@ namespace SolastaModHelpers.Patches
         internal static bool Prefix(CharacterActionParams actionParams, ref CharacterAction __result)
         {
             var type_name = nameof(CharacterAction) + (string.IsNullOrEmpty(actionParams.ActionDefinition.ClassNameOverride) ? actionParams.ActionDefinition.Name : actionParams.ActionDefinition.ClassNameOverride);
-            var type = System.Type.GetType(type_name);
+            var type = Type.GetType(type_name);
             if (type != null)
             {
                 //action type is defined locally

--- a/SolastaModHelpers/Patches/DoNotApplySpellOnSelfPatcher.cs
+++ b/SolastaModHelpers/Patches/DoNotApplySpellOnSelfPatcher.cs
@@ -1,9 +1,5 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using SolastaModApi.Infrastructure;
 
 namespace SolastaModHelpers.Patches
 {
@@ -19,18 +15,18 @@ namespace SolastaModHelpers.Patches
                     return;
                 }
 
-                var tr = HarmonyLib.Traverse.Create(__instance);
-                var effect = tr.Field("effectDescription").GetValue<EffectDescription>();
+                var effect = __instance.GetField<EffectDescription>("effectDescription");
+
                 var tag = (ExtendedEnums.ExtraTargetFilteringTag)effect.TargetFilteringTag;
                 if (effect == null || (tag & ExtendedEnums.ExtraTargetFilteringTag.NonCaster) == ExtendedEnums.ExtraTargetFilteringTag.No)
                 {
                     return;
                 }
 
-                __result =  target != __instance.ActionParams.ActingCharacter;
+                __result = target != __instance.ActionParams.ActingCharacter;
                 if (!__result)
                 {
-                    var action_modifier = tr.Field("actionModifier").GetValue<ActionModifier>();
+                    var action_modifier = __instance.GetField<ActionModifier>("actionModifier");
                     action_modifier.FailureFlags.Add("Failure/&FailureFlagTargetIncorrectCreatureFamily");
                 }
                 return;

--- a/SolastaModHelpers/Patches/GameLocationBattleManagerPatcher.cs
+++ b/SolastaModHelpers/Patches/GameLocationBattleManagerPatcher.cs
@@ -1,10 +1,7 @@
 ﻿using HarmonyLib;
 using SolastaModHelpers.NewFeatureDefinitions;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {
@@ -31,15 +28,15 @@ namespace SolastaModHelpers.Patches
 
                     List<System.Collections.IEnumerator> extra_events = new List<System.Collections.IEnumerator>();
 
-                    var units = __instance.Battle.AllContenders;                   
+                    var units = __instance.Battle.AllContenders;
                     foreach (GameLocationCharacter unit in units)
                     {
-                        if (!unit.RulesetCharacter.IsDeadOrDyingOrUnconscious 
+                        if (!unit.RulesetCharacter.IsDeadOrDyingOrUnconscious
                             && unit.GetActionTypeStatus(ActionDefinitions.ActionType.Reaction, ActionDefinitions.ActionScope.Battle, false) == ActionDefinitions.ActionStatus.Available)
                         {
-                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is NewFeatureDefinitions.IReactionPowerOnAttackAttempt 
+                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is IReactionPowerOnAttackAttempt
                                                                                   && unit.RulesetCharacter.GetRemainingUsesOfPower(u) > 0
-                                                                                  && (u.PowerDefinition as NewFeatureDefinitions.IReactionPowerOnAttackAttempt)
+                                                                                  && (u.PowerDefinition as IReactionPowerOnAttackAttempt)
                                                                                     .canBeUsed(unit, attacker, defender, attackerAttackMode)
                                                                                  ).ToArray();
                             var overriden_powers = powers.Aggregate(new List<FeatureDefinitionPower>(), (old, next) =>
@@ -62,7 +59,7 @@ namespace SolastaModHelpers.Patches
                                 reactionParams.UsablePower = p;
                                 IRulesetImplementationService service1 = ServiceRepository.GetService<IRulesetImplementationService>();
                                 reactionParams.RulesetEffect = (RulesetEffect)service1.InstantiateEffectPower(attacker.RulesetCharacter, p, false);
-                                reactionParams.StringParameter = p.PowerDefinition.Name;                                
+                                reactionParams.StringParameter = p.PowerDefinition.Name;
                                 reactionParams.IsReactionEffect = true;
                                 IGameLocationActionService service2 = ServiceRepository.GetService<IGameLocationActionService>();
                                 int count = service2.PendingReactionRequestGroups.Count;
@@ -111,9 +108,9 @@ namespace SolastaModHelpers.Patches
                         if (!unit.RulesetCharacter.IsDeadOrDyingOrUnconscious
                             && unit.GetActionTypeStatus(ActionDefinitions.ActionType.Reaction, ActionDefinitions.ActionScope.Battle, false) == ActionDefinitions.ActionStatus.Available)
                         {
-                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is NewFeatureDefinitions.IReactionPowerOnDamage
+                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is IReactionPowerOnDamage
                                                                                   && unit.RulesetCharacter.GetRemainingUsesOfPower(u) > 0
-                                                                                  && (u.PowerDefinition as NewFeatureDefinitions.IReactionPowerOnDamage)
+                                                                                  && (u.PowerDefinition as IReactionPowerOnDamage)
                                                                                     .canBeUsed(unit, attacker, defender, null, true)
                                                                                  ).ToArray();
 
@@ -184,9 +181,9 @@ namespace SolastaModHelpers.Patches
                         if (!unit.RulesetCharacter.IsDeadOrDyingOrUnconscious
                             && unit.GetActionTypeStatus(ActionDefinitions.ActionType.Reaction, ActionDefinitions.ActionScope.Battle, false) == ActionDefinitions.ActionStatus.Available)
                         {
-                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is NewFeatureDefinitions.IReactionPowerOnDamage
+                            var powers = unit.RulesetCharacter.UsablePowers.Where(u => u.PowerDefinition is IReactionPowerOnDamage
                                                                                   && unit.RulesetCharacter.GetRemainingUsesOfPower(u) > 0
-                                                                                  && (u.PowerDefinition as NewFeatureDefinitions.IReactionPowerOnDamage)
+                                                                                  && (u.PowerDefinition as IReactionPowerOnDamage)
                                                                                     .canBeUsed(unit, attacker, defender, attackMode, false)
                                                                                  ).ToArray();
 

--- a/SolastaModHelpers/Patches/GameManagerPatcher.cs
+++ b/SolastaModHelpers/Patches/GameManagerPatcher.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using UnityModManagerNet;
 
 namespace SolastaModHelpers.Patches
 {

--- a/SolastaModHelpers/Patches/OnRestPatches.cs
+++ b/SolastaModHelpers/Patches/OnRestPatches.cs
@@ -1,9 +1,5 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 namespace SolastaModHelpers.Patches
 {
     class RestModuleHitDicePatcher

--- a/SolastaModHelpers/Patches/RitualSpellsPatches.cs
+++ b/SolastaModHelpers/Patches/RitualSpellsPatches.cs
@@ -1,9 +1,5 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {

--- a/SolastaModHelpers/Patches/RulesetActorPatches.cs
+++ b/SolastaModHelpers/Patches/RulesetActorPatches.cs
@@ -1,9 +1,5 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {

--- a/SolastaModHelpers/Patches/RulesetCharacterPatches.cs
+++ b/SolastaModHelpers/Patches/RulesetCharacterPatches.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {
@@ -54,7 +52,7 @@ namespace SolastaModHelpers.Patches
                 if (base_power == null)
                 {
                     return;
-                    
+
                 }
                 base_power.Consume();
             }
@@ -69,9 +67,9 @@ namespace SolastaModHelpers.Patches
                 var codes = instructions.ToList();
                 var check_remaining_uses = codes.FindIndex(x => x.opcode == System.Reflection.Emit.OpCodes.Callvirt && x.operand.ToString().Contains("RemainingUses"));
 
-                codes[check_remaining_uses] = new HarmonyLib.CodeInstruction(System.Reflection.Emit.OpCodes.Ldarg_0);
+                codes[check_remaining_uses] = new CodeInstruction(System.Reflection.Emit.OpCodes.Ldarg_0);
                 codes.Insert(check_remaining_uses + 1,
-                              new HarmonyLib.CodeInstruction(System.Reflection.Emit.OpCodes.Call,
+                              new CodeInstruction(System.Reflection.Emit.OpCodes.Call,
                                                              new Func<RulesetUsablePower, RulesetCharacter, int>(getNumberOfRemainingUses).Method
                                                              )
                             );
@@ -93,9 +91,9 @@ namespace SolastaModHelpers.Patches
                 var codes = instructions.ToList();
                 var check_remaining_uses = codes.FindIndex(x => x.opcode == System.Reflection.Emit.OpCodes.Callvirt && x.operand.ToString().Contains("RemainingUses"));
 
-                codes[check_remaining_uses] = new HarmonyLib.CodeInstruction(System.Reflection.Emit.OpCodes.Ldarg_0);
+                codes[check_remaining_uses] = new CodeInstruction(System.Reflection.Emit.OpCodes.Ldarg_0);
                 codes.Insert(check_remaining_uses + 1,
-                              new HarmonyLib.CodeInstruction(System.Reflection.Emit.OpCodes.Call,
+                              new CodeInstruction(System.Reflection.Emit.OpCodes.Call,
                                                              new Func<RulesetUsablePower, RulesetCharacter, int>(getNumberOfRemainingUses).Method
                                                              )
                             );

--- a/SolastaModHelpers/Patches/SpellRepertoirePatches.cs
+++ b/SolastaModHelpers/Patches/SpellRepertoirePatches.cs
@@ -1,9 +1,6 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Patches
 {
@@ -113,7 +110,7 @@ namespace SolastaModHelpers.Patches
                             {
                                 continue;
                             }
-                            
+
                             foreach (var s in sg.SpellsList)
                             {
                                 spells.Add(s);

--- a/SolastaModHelpers/StringProcessing.cs
+++ b/SolastaModHelpers/StringProcessing.cs
@@ -1,9 +1,6 @@
 ﻿using I2.Loc;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SolastaModHelpers.Helpers
 {
@@ -111,7 +108,7 @@ namespace SolastaModHelpers.Helpers
         }
 
 
-        public static void addPowerReactStrings(FeatureDefinitionPower power, string use_power_title, string use_power_description, 
+        public static void addPowerReactStrings(FeatureDefinitionPower power, string use_power_title, string use_power_description,
                                                string react_title, string react_description)
         {
             var power_name = power.name;

--- a/SolastaModHelpers/path.cs
+++ b/SolastaModHelpers/path.cs
@@ -1,1 +1,1 @@
-namespace ProjectPath { static public class ProjectPath { public static readonly string Path = @"C:\Repositories\Solasta\SolastaModHelpers\SolastaModHelpers\";} } 
+namespace ProjectPath { static public class ProjectPath { public static readonly string Path = @"C:\Users\passp\Source\Repos\SolastaModHelpers\SolastaModHelpers\";} } 


### PR DESCRIPTION
No need to duplicate strings like Strength, Dexterity etc.  Already defined as AttributeDefinitions.Strength, etc., SkillDefinitions.*, etc.

There are already helpers that wrap Traverse in ModApi. GetField, SetField.